### PR TITLE
Update Makefile to fix threading seg fault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ALL: TC3
 TC3: sequencer.cc server.cc DAQ.cc DAQ.h DO.cc DO.h TransferFunctions.cc TransferFunctions.h database.cc database.h
-	g++ -std=c++0x -Wall -g DAQ.cc DO.cc TransferFunctions.cc database.cc fparser4.5.2/fparser.cc sequencer.cc server.cc -o TC3 -lboost_system -lrt -lpci_dask -lpq -I/usr/include/postgresql
+	g++ -std=c++0x -Wall -g DAQ.cc DO.cc TransferFunctions.cc database.cc fparser4.5.2/fparser.cc sequencer.cc server.cc -o TC3 -lboost_system -lrt -lpci_dask -lpq -I/usr/include/postgresql -Wl --no-as-needed
 clean:
 	rm TC3


### PR DESCRIPTION
I think this will fix the seg fault that gets thrown near the std::Mutex call in sequencer.cc. Apparently there is a g++ bug that causes this or something. I will try and update gcc, and if that doesn't work I will try this....